### PR TITLE
Volunteering and Publications Endpoints

### DIFF
--- a/app/Controllers/User/publication_controller.py
+++ b/app/Controllers/User/publication_controller.py
@@ -1,0 +1,82 @@
+from typing import List
+from fastapi import APIRouter, Depends, Query
+from uuid import UUID
+from sqlmodel import Session
+
+from Settings.logging_config import setup_logging
+from Entities.UserDTOs.publication_entity import (
+    CreatePublication,
+    ReadPublication,
+    ReadPublicationWithRelations,
+    UpdatePublication,
+)
+from Services.User.publication_service import PublicationService
+from db import get_session
+
+logger = setup_logging()
+
+router = APIRouter(prefix="/Dijkstra/v1/publications", tags=["Publications"])
+
+
+@router.post("/", response_model=ReadPublication)
+def create_publication(publication_create: CreatePublication, session: Session = Depends(get_session)):
+    service = PublicationService(session)
+    logger.info(f"Creating publication: {publication_create.title} by {publication_create.publisher}")
+    publication = service.create_publication(publication_create)
+    logger.info(f"Created publication with ID: {publication.id}")
+    return publication
+
+
+@router.get("/{publication_id}", response_model=ReadPublicationWithRelations)
+def get_publication(publication_id: UUID, session: Session = Depends(get_session)):
+    service = PublicationService(session)
+    logger.info(f"Fetching publication with ID: {publication_id}")
+    publication = service.get_publication(publication_id)
+    logger.info(f"Fetched publication with ID: {publication.id}")
+    return publication
+
+
+@router.get("/profile/{profile_id}", response_model=List[ReadPublication])
+def get_publications_by_profile_id(profile_id: UUID, session: Session = Depends(get_session)):
+    service = PublicationService(session)
+    logger.info(f"Fetching publications for profile ID: {profile_id}")
+    publications = service.get_publications_by_profile_id(profile_id)
+    logger.info(f"Returned {len(publications)} publications for profile {profile_id}")
+    return publications
+
+
+@router.get("/", response_model=List[ReadPublication])
+def list_publications(
+    skip: int = 0,
+    limit: int = 20,
+    session: Session = Depends(get_session),
+):
+    service = PublicationService(session)
+    logger.info(f"Listing publications: skip={skip}, limit={limit}")
+    publications = service.list_publications(skip=skip, limit=limit)
+
+    if not publications:
+        logger.info("No publications found")
+        return []
+
+    logger.info(f"Returned {len(publications)} publications")
+    return publications
+
+
+
+@router.put("/{publication_id}", response_model=ReadPublication)
+def update_publication(publication_id: UUID, publication_update: UpdatePublication, session: Session = Depends(get_session)):
+    service = PublicationService(session)
+    logger.info(f"Updating publication ID: {publication_id} with data: {publication_update.dict(exclude_unset=True)}")
+    publication = service.update_publication(publication_id, publication_update)
+    logger.info(f"Updated publication ID: {publication.id}")
+    return publication
+
+
+@router.delete("/{publication_id}")
+def delete_publication(publication_id: UUID, session: Session = Depends(get_session)):
+    service = PublicationService(session)
+    logger.info(f"Deleting publication ID: {publication_id}")
+    message = service.delete_publication(publication_id)
+    logger.info(f"Deleted publication ID: {publication_id}")
+    return {"detail": message}

--- a/app/Controllers/User/volunteering_controller.py
+++ b/app/Controllers/User/volunteering_controller.py
@@ -1,0 +1,71 @@
+from typing import List
+from fastapi import APIRouter, Depends, Query
+from uuid import UUID
+from sqlmodel import Session
+
+from Settings.logging_config import setup_logging
+from Entities.UserDTOs.volunteering_entity import CreateVolunteering, ReadVolunteering, ReadVolunteeringWithRelations, UpdateVolunteering
+from Services.User.volunteering_service import VolunteeringService
+from db import get_session
+
+logger = setup_logging()
+
+router = APIRouter(prefix="/Dijkstra/v1/volunteering", tags=["Volunteering"])
+
+
+@router.post("/", response_model=ReadVolunteering)
+def create_volunteering(volunteering_create: CreateVolunteering, session: Session = Depends(get_session)):
+    service = VolunteeringService(session)
+    logger.info(f"Creating volunteering at {volunteering_create.organization} for role {volunteering_create.role}")
+    volunteering = service.create_volunteering(volunteering_create)
+    logger.info(f"Created volunteering with ID: {volunteering.id}")
+    return volunteering
+
+
+@router.get("/{volunteering_id}", response_model=ReadVolunteeringWithRelations)
+def get_volunteering(volunteering_id: UUID, session: Session = Depends(get_session)):
+    service = VolunteeringService(session)
+    logger.info(f"Fetching volunteering with ID: {volunteering_id}")
+    volunteering = service.get_volunteering(volunteering_id)
+    logger.info(f"Fetched volunteering with ID: {volunteering.id}")
+    return volunteering
+
+
+@router.get("/profile/{profile_id}", response_model=List[ReadVolunteering])
+def get_volunteering_by_profile_id(profile_id: UUID, session: Session = Depends(get_session)):
+    service = VolunteeringService(session)
+    logger.info(f"Fetching volunteering entries for profile ID: {profile_id}")
+    volunteering_entries = service.get_volunteering_by_profile_id(profile_id)
+    logger.info(f"Returned {len(volunteering_entries)} volunteering entries for profile {profile_id}")
+    return volunteering_entries
+
+
+@router.get("/", response_model=List[ReadVolunteering])
+def list_volunteering(
+    skip: int = 0,
+    limit: int = 20,
+    session: Session = Depends(get_session),
+):
+    service = VolunteeringService(session)
+    logger.info(f"Listing volunteering entries: skip={skip}, limit={limit}")
+    volunteering_entries = service.list_volunteering(skip=skip, limit=limit)
+    logger.info(f"Returned {len(volunteering_entries)} volunteering entries")
+    return volunteering_entries
+
+
+@router.put("/{volunteering_id}", response_model=ReadVolunteering)
+def update_volunteering(volunteering_id: UUID, volunteering_update: UpdateVolunteering, session: Session = Depends(get_session)):
+    service = VolunteeringService(session)
+    logger.info(f"Updating volunteering ID: {volunteering_id} with data: {volunteering_update.dict(exclude_unset=True)}")
+    volunteering = service.update_volunteering(volunteering_id, volunteering_update)
+    logger.info(f"Updated volunteering ID: {volunteering.id}")
+    return volunteering
+
+
+@router.delete("/{volunteering_id}")
+def delete_volunteering(volunteering_id: UUID, session: Session = Depends(get_session)):
+    service = VolunteeringService(session)
+    logger.info(f"Deleting volunteering ID: {volunteering_id}")
+    message = service.delete_volunteering(volunteering_id)
+    logger.info(f"Deleted volunteering ID: {volunteering_id}")
+    return {"detail": message}

--- a/app/Entities/UserDTOs/publication_entity.py
+++ b/app/Entities/UserDTOs/publication_entity.py
@@ -1,0 +1,120 @@
+from typing import Optional, List
+from uuid import UUID
+from datetime import date, datetime
+from pydantic import BaseModel, field_validator
+
+from Schema.SQL.Enums.enums import Tools  
+
+
+# ----------------------
+# Input DTOs
+# ----------------------
+class CreatePublication(BaseModel):
+    profile_id: UUID
+    title: str
+    publisher: str
+    authors: List[str]
+    publication_date: date
+    publication_url: str
+    description: str
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("title")
+    def title_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("title cannot be empty")
+        return v.strip()
+
+    @field_validator("publisher")
+    def publisher_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("publisher cannot be empty")
+        return v.strip()
+
+    @field_validator("authors")
+    def authors_must_not_be_empty(cls, v):
+        if not v or len(v) == 0:
+            raise ValueError("authors cannot be empty")
+        return v
+
+    @field_validator("publication_url")
+    def url_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("publication_url cannot be empty")
+        return v.strip()
+
+    @field_validator("description")
+    def description_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("description cannot be empty")
+        return v.strip()
+
+
+class UpdatePublication(BaseModel):
+    profile_id: Optional[UUID] = None
+    title: Optional[str] = None
+    publisher: Optional[str] = None
+    authors: Optional[List[str]] = None
+    publication_date: Optional[date] = None
+    publication_url: Optional[str] = None
+    description: Optional[str] = None
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("title")
+    def title_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("title cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("publisher")
+    def publisher_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("publisher cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("publication_url")
+    def url_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("publication_url cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("description")
+    def description_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("description cannot be empty")
+        return v.strip() if v else v
+
+
+# ----------------------
+# Output DTO
+# ----------------------
+class ReadPublication(BaseModel):
+    id: UUID
+    profile_id: UUID
+    title: str
+    publisher: str
+    authors: List[str]
+    publication_date: date
+    publication_url: str
+    description: str
+    tools: Optional[List[Tools]]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------
+# Extended Output DTO with related entities
+# ----------------------
+class ReadPublicationWithRelations(ReadPublication):
+    profile: Optional["ReadProfile"] = None
+
+    class Config:
+        orm_mode = True
+
+
+# Import here to avoid circular imports
+from Entities.UserDTOs.profile_entity import ReadProfile
+ReadPublicationWithRelations.model_rebuild()

--- a/app/Entities/UserDTOs/volunteering_entity.py
+++ b/app/Entities/UserDTOs/volunteering_entity.py
@@ -1,0 +1,111 @@
+from typing import Optional, List
+from uuid import UUID
+from datetime import date, datetime
+from pydantic import BaseModel, ValidationInfo, field_validator
+
+from Schema.SQL.Enums.enums import (
+    Cause,
+    Tools,
+)  # assuming Cause is your USER-DEFINED enum
+
+
+# ----------------------
+# Input DTOs
+# ----------------------
+class CreateVolunteering(BaseModel):
+    profile_id: UUID
+    organization: str
+    role: str
+    cause: Cause
+    start_date: date
+    end_date: Optional[date] = None
+    currently_volunteering: bool
+    description: Optional[str] = None
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("organization")
+    def organization_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("organization cannot be empty")
+        return v.strip()
+
+    @field_validator("role")
+    def role_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("role cannot be empty")
+        return v.strip()
+
+    @field_validator("end_date")
+    def validate_end_date(cls, v, info: ValidationInfo):
+        start_date = info.data.get("start_date")
+        if v and start_date and v < start_date:
+            raise ValueError("end_date cannot be before start_date")
+        return v
+
+
+class UpdateVolunteering(BaseModel):
+    profile_id: Optional[UUID] = None
+    organization: Optional[str] = None
+    role: Optional[str] = None
+    cause: Optional[Cause] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    currently_volunteering: Optional[bool] = None
+    description: Optional[str] = None
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("organization")
+    def organization_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("organization cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("role")
+    def role_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("role cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("end_date")
+    def validate_end_date(cls, v, info: ValidationInfo):
+        start_date = info.data.get("start_date")
+        if v and start_date and v < start_date:
+            raise ValueError("end_date cannot be before start_date")
+        return v
+
+
+# ----------------------
+# Output DTO
+# ----------------------
+class ReadVolunteering(BaseModel):
+    id: UUID
+    profile_id: UUID
+    organization: str
+    role: str
+    cause: Cause
+    start_date: date
+    end_date: Optional[date]
+    currently_volunteering: bool
+    description: Optional[str]
+    tools: Optional[List[Tools]]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------
+# Extended Output DTO with related entities
+# ----------------------
+class ReadVolunteeringWithRelations(ReadVolunteering):
+    profile: Optional["ReadProfile"] = None
+
+    class Config:
+        orm_mode = True
+
+
+# Avoid circular imports
+from Entities.UserDTOs.profile_entity import ReadProfile
+
+ReadVolunteeringWithRelations.model_rebuild()

--- a/app/Repository/User/publication_repository.py
+++ b/app/Repository/User/publication_repository.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlmodel import Session, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from Schema.SQL.Models.models import Publications
+
+
+class PublicationRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create(self, publication: Publications) -> Publications:
+        try:
+            self.session.add(publication)
+            self.session.commit()
+            self.session.refresh(publication)
+            return publication
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise
+
+    def get(self, publication_id: UUID) -> Optional[Publications]:
+        statement = select(Publications).where(Publications.id == publication_id)
+        return self.session.exec(statement).first()
+
+    def list(self, skip: int = 0, limit: int = 20) -> List[Publications]:
+        statement = select(Publications).offset(skip).limit(limit)
+        return self.session.exec(statement).all()
+
+    def get_by_profile_id(self, profile_id: UUID) -> List[Publications]:
+        statement = select(Publications).where(Publications.profile_id == profile_id)
+        return self.session.exec(statement).all()
+
+    def update(self, publication: Publications) -> Publications:
+        try:
+            self.session.add(publication)
+            self.session.commit()
+            self.session.refresh(publication)
+            return publication
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise
+
+    def delete(self, publication: Publications):
+        try:
+            self.session.delete(publication)
+            self.session.commit()
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise

--- a/app/Repository/User/volunteering_repository.py
+++ b/app/Repository/User/volunteering_repository.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlmodel import Session, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from Schema.SQL.Models.models import Volunteering
+
+
+class VolunteeringRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create(self, volunteering: Volunteering) -> Volunteering:
+        try:
+            self.session.add(volunteering)
+            self.session.commit()
+            self.session.refresh(volunteering)
+            return volunteering
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise
+
+    def get(self, volunteering_id: UUID) -> Optional[Volunteering]:
+        statement = select(Volunteering).where(Volunteering.id == volunteering_id)
+        return self.session.exec(statement).first()
+
+    def list(self, skip: int = 0, limit: int = 20) -> List[Volunteering]:
+        statement = select(Volunteering).offset(skip).limit(limit)
+        return self.session.exec(statement).all()
+
+    def get_by_profile_id(self, profile_id: UUID) -> List[Volunteering]:
+        statement = select(Volunteering).where(Volunteering.profile_id == profile_id)
+        return self.session.exec(statement).all()
+
+    def update(self, volunteering: Volunteering) -> Volunteering:
+        try:
+            self.session.add(volunteering)
+            self.session.commit()
+            self.session.refresh(volunteering)
+            return volunteering
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise
+
+    def delete(self, volunteering: Volunteering):
+        try:
+            self.session.delete(volunteering)
+            self.session.commit()
+        except SQLAlchemyError:
+            self.session.rollback()
+            raise

--- a/app/Schema/volunteering_entity.py
+++ b/app/Schema/volunteering_entity.py
@@ -1,0 +1,111 @@
+from typing import Optional, List
+from uuid import UUID
+from datetime import date, datetime
+from pydantic import BaseModel, ValidationInfo, field_validator
+
+from Schema.SQL.Enums.enums import (
+    Cause,
+    Tools,
+)  # assuming Cause is your USER-DEFINED enum
+
+
+# ----------------------
+# Input DTOs
+# ----------------------
+class CreateVolunteering(BaseModel):
+    profile_id: UUID
+    organization: str
+    role: str
+    cause: Cause
+    start_date: date
+    end_date: Optional[date] = None
+    currently_volunteering: bool
+    description: Optional[str] = None
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("organization")
+    def organization_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("organization cannot be empty")
+        return v.strip()
+
+    @field_validator("role")
+    def role_must_not_be_empty(cls, v):
+        if not v.strip():
+            raise ValueError("role cannot be empty")
+        return v.strip()
+
+    @field_validator("end_date")
+    def validate_end_date(cls, v, info: ValidationInfo):
+        start_date = info.data.get("start_date")
+        if v and start_date and v < start_date:
+            raise ValueError("end_date cannot be before start_date")
+        return v
+
+
+class UpdateVolunteering(BaseModel):
+    profile_id: Optional[UUID] = None
+    organization: Optional[str] = None
+    role: Optional[str] = None
+    cause: Optional[Cause] = None
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    currently_volunteering: Optional[bool] = None
+    description: Optional[str] = None
+    tools: Optional[List[Tools]] = None
+
+    @field_validator("organization")
+    def organization_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("organization cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("role")
+    def role_must_not_be_empty(cls, v):
+        if v is not None and not v.strip():
+            raise ValueError("role cannot be empty")
+        return v.strip() if v else v
+
+    @field_validator("end_date")
+    def validate_end_date(cls, v, info: ValidationInfo):
+        start_date = info.data.get("start_date")
+        if v and start_date and v < start_date:
+            raise ValueError("end_date cannot be before start_date")
+        return v
+
+
+# ----------------------
+# Output DTO
+# ----------------------
+class ReadVolunteering(BaseModel):
+    id: UUID
+    profile_id: UUID
+    organization: str
+    role: str
+    cause: Cause
+    start_date: date
+    end_date: Optional[date]
+    currently_volunteering: bool
+    description: Optional[str]
+    tools: Optional[List[Tools]]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------
+# Extended Output DTO with related entities
+# ----------------------
+class ReadVolunteeringWithRelations(ReadVolunteering):
+    profile: Optional["ReadProfile"] = None
+
+    class Config:
+        orm_mode = True
+
+
+# Avoid circular imports
+from Entities.UserDTOs.profile_entity import ReadProfile
+
+ReadVolunteeringWithRelations.model_rebuild()

--- a/app/Services/User/publication_service.py
+++ b/app/Services/User/publication_service.py
@@ -1,0 +1,73 @@
+from uuid import UUID
+from typing import List, Optional
+from sqlmodel import Session
+
+from Schema.SQL.Models.models import Publications, Profile
+from Repository.User.publication_repository import PublicationRepository
+from Entities.UserDTOs.publication_entity import CreatePublication, UpdatePublication
+from Utils.Exceptions.user_exceptions import ProfileNotFound, PublicationNotFound
+
+
+class PublicationService:
+    def __init__(self, session: Session):
+        self.repo = PublicationRepository(session)
+        self.session = session
+
+    def create_publication(self, publication_create: CreatePublication) -> Publications:
+        # Ensure profile exists
+        profile = self.session.get(Profile, publication_create.profile_id)
+        if not profile:
+            raise ProfileNotFound(publication_create.profile_id)
+
+        publication = Publications(**publication_create.dict(exclude_unset=True))
+        return self.repo.create(publication)
+
+    def get_publication(self, publication_id: UUID) -> Publications:
+        publication = self.repo.get(publication_id)
+        if not publication:
+            raise PublicationNotFound(publication_id)
+        return publication
+
+    def list_publications(self, skip: int = 0, limit: int = 20):
+        publications = self.repo.list(skip=skip, limit=limit)
+        if not publications:
+            # Instead of raising error, return empty list
+            return []
+        return publications
+
+    def get_publications_by_profile_id(self, profile_id: UUID) -> List[Publications]:
+        publications = self.repo.get_by_profile_id(profile_id)
+        if not publications:
+            # raise PublicationNotFound(profile_id)
+            return []
+        return publications
+
+    def update_publication(
+        self, publication_id: UUID, publication_update: UpdatePublication
+    ) -> Publications:
+        publication = self.repo.get(publication_id)
+        if not publication:
+            raise PublicationNotFound(publication_id)
+
+        # If profile_id is updated, ensure the profile exists
+        if (
+            publication_update.profile_id
+            and publication_update.profile_id != publication.profile_id
+        ):
+            profile = self.session.get(Profile, publication_update.profile_id)
+            if not profile:
+                raise ProfileNotFound(publication_update.profile_id)
+
+        update_data = publication_update.dict(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(publication, key, value)
+
+        return self.repo.update(publication)
+
+    def delete_publication(self, publication_id: UUID) -> str:
+        publication = self.repo.get(publication_id)
+        if not publication:
+            raise PublicationNotFound(publication_id)
+
+        self.repo.delete(publication)
+        return f"Publication {publication_id} deleted successfully"

--- a/app/Services/User/volunteering_service.py
+++ b/app/Services/User/volunteering_service.py
@@ -1,0 +1,63 @@
+from uuid import UUID
+from typing import List, Optional
+from sqlmodel import Session
+
+from Schema.SQL.Models.models import Volunteering, Profile
+from Repository.User.volunteering_repository import VolunteeringRepository
+from Entities.UserDTOs.volunteering_entity import CreateVolunteering, UpdateVolunteering
+from Utils.Exceptions.user_exceptions import ProfileNotFound, VolunteeringNotFound
+
+
+class VolunteeringService:
+    def __init__(self, session: Session):
+        self.repo = VolunteeringRepository(session)
+        self.session = session
+
+    def create_volunteering(self, volunteering_create: CreateVolunteering) -> Volunteering:
+        # Ensure profile exists
+        profile = self.session.get(Profile, volunteering_create.profile_id)
+        if not profile:
+            raise ProfileNotFound(volunteering_create.profile_id)
+
+        volunteering = Volunteering(**volunteering_create.dict(exclude_unset=True))
+        return self.repo.create(volunteering)
+
+    def get_volunteering(self, volunteering_id: UUID) -> Volunteering:
+        volunteering = self.repo.get(volunteering_id)
+        if not volunteering:
+            raise VolunteeringNotFound(volunteering_id)
+        return volunteering
+
+    def list_volunteering(self, skip: int = 0, limit: int = 20) -> List[Volunteering]:
+        return self.repo.list(skip=skip, limit=limit)
+
+    def get_volunteering_by_profile_id(self, profile_id: UUID) -> List[Volunteering]:
+        volunteering_entries = self.repo.get_by_profile_id(profile_id)
+        if not volunteering_entries:
+            raise VolunteeringNotFound(profile_id)
+        return volunteering_entries
+
+    def update_volunteering(self, volunteering_id: UUID, volunteering_update: UpdateVolunteering) -> Volunteering:
+        volunteering = self.repo.get(volunteering_id)
+        if not volunteering:
+            raise VolunteeringNotFound(volunteering_id)
+
+        # If profile_id is updated, ensure the profile exists
+        if volunteering_update.profile_id and volunteering_update.profile_id != volunteering.profile_id:
+            profile = self.session.get(Profile, volunteering_update.profile_id)
+            if not profile:
+                raise ProfileNotFound(volunteering_update.profile_id)
+
+        update_data = volunteering_update.dict(exclude_unset=True)
+        for key, value in update_data.items():
+            setattr(volunteering, key, value)
+
+        return self.repo.update(volunteering)
+
+    def delete_volunteering(self, volunteering_id: UUID) -> str:
+        volunteering = self.repo.get(volunteering_id)
+        if not volunteering:
+            raise VolunteeringNotFound(volunteering_id)
+
+        self.repo.delete(volunteering)
+        return f"Volunteering {volunteering_id} deleted successfully"

--- a/app/Utils/Exceptions/user_exceptions.py
+++ b/app/Utils/Exceptions/user_exceptions.py
@@ -37,3 +37,13 @@ class GitHubUsernameAlreadyExists(ServiceError):
     def __init__(self, github_username):
         super().__init__(f"User with GitHub username '{github_username}' already exists.")
         self.github_username = github_username
+
+class VolunteeringNotFound(ServiceError):
+    def __init__(self, volunteering_id):
+        super().__init__(f"Volunteering entry with ID {volunteering_id} does not exist.")
+        self.volunteering_id = volunteering_id
+
+class PublicationNotFound(ServiceError):
+    def __init__(self, publication_id):
+        super().__init__(f"Publication with ID {publication_id} does not exist.")
+        self.publication_id = publication_id

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from fastapi import Depends, FastAPI
 from Settings.logging_config import setup_logging
 from Controllers import main_controller
 from Controllers.Opportunities import job_controller
-from Controllers.User import certificate_controller, workexperience_controller, profile_controller, user_controller
+from Controllers.User import certificate_controller, workexperience_controller, profile_controller, user_controller, volunteering_controller, publication_controller
 from Controllers.Opportunities import fellowships_controller, organization_controller, projects_opportunities_controller
 from Controllers.User import location_controller
 from Controllers.error_handlers import register_exception_handlers
@@ -36,3 +36,5 @@ app.include_router(job_controller.router)
 app.include_router(fellowships_controller.router)
 app.include_router(organization_controller.router)
 app.include_router(projects_opportunities_controller.router)
+app.include_router(volunteering_controller.router)
+app.include_router(publication_controller.router)


### PR DESCRIPTION
## 📌 Publications & Volunteering Endpoints Overview

---

### 📖 Publications

**Base path:** `/Dijkstra/v1/publications`

1. **Create Publication**  
   - `POST /publications`  
   - Creates a new publication entry for a profile.

2. **Get Publication by ID**  
   - `GET /publications/{publication_id}`  
   - Fetches a single publication entry with related profile details.

3. **Get All Publications by Profile**  
   - `GET /publications/profile/{profile_id}`  
   - Returns all publication records linked to a given profile.  
   - ⚡ Useful for displaying all publications of a user.

4. **List Publications (paginated)**  
   - `GET /publications?skip=0&limit=20`  
   - Returns publications with basic pagination.

5. **Update Publication**  
   - `PUT /publications/{publication_id}`  
   - Updates an existing publication entry (partial or full).

6. **Delete Publication**  
   - `DELETE /publications/{publication_id}`  
   - Deletes a publication entry by ID.

---

### 🙌 Volunteering

**Base path:** `/Dijkstra/v1/volunteering`

1. **Create Volunteering**  
   - `POST /volunteering`  
   - Creates a new volunteering entry for a profile.

2. **Get Volunteering by ID**  
   - `GET /volunteering/{volunteering_id}`  
   - Fetches a single volunteering entry with related profile details.

3. **Get All Volunteering by Profile**  
   - `GET /volunteering/profile/{profile_id}`  
   - Returns all volunteering records linked to a given profile.  
   - ⚡ This was the key frontend requirement.

4. **List Volunteering (paginated)**  
   - `GET /volunteering?skip=0&limit=20`  
   - Returns volunteering entries with basic pagination.

5. **Update Volunteering**  
   - `PUT /volunteering/{volunteering_id}`  
   - Updates an existing volunteering entry (partial or full).

6. **Delete Volunteering**  
   - `DELETE /volunteering/{volunteering_id}`  
   - Deletes a volunteering entry by ID.
