### PR TITLE
prevent duplicate logging handlers

### DIFF
--- a/app/Controllers/Opportunities/fellowships_controller.py
+++ b/app/Controllers/Opportunities/fellowships_controller.py
@@ -7,9 +7,9 @@ import logging
 from Entities.OpportunityDTOs.fellowships_entity import CreateFellowship, UpdateFellowship, ReadFellowship
 from Services.Opportunities.fellowships_service import FellowshipService
 from db import get_session
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/fellowships", tags=["Fellowships"])
 

--- a/app/Controllers/Opportunities/job_controller.py
+++ b/app/Controllers/Opportunities/job_controller.py
@@ -4,10 +4,10 @@ from uuid import UUID
 from sqlmodel import Session
 from Entities.OpportunityDTOs.jobs_entity import CreateJob, UpdateJob, ReadJob
 from Services.Opportunities.jobs_service import JobService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/jobs", tags=["Jobs"])
 

--- a/app/Controllers/Opportunities/organization_controller.py
+++ b/app/Controllers/Opportunities/organization_controller.py
@@ -5,10 +5,10 @@ from uuid import UUID
 from sqlmodel import Session
 from Entities.OpportunityDTOs.organization_entity import CreateOrganization, UpdateOrganization, ReadOrganization
 from Services.Opportunities.organization_service import OrganizationService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/organizations", tags=["Organizations"])
 

--- a/app/Controllers/Opportunities/projects_opportunities_controller.py
+++ b/app/Controllers/Opportunities/projects_opportunities_controller.py
@@ -5,10 +5,10 @@ from uuid import UUID
 from sqlmodel import Session
 from Entities.OpportunityDTOs.projects_opportunities_entity import CreateProject, UpdateProject, ReadProject
 from Services.Opportunities.projects_opportunities_service import ProjectsOpportunitiesService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/projects/opportunities", tags=["ProjectsOpportunities"])
 

--- a/app/Controllers/User/certifications_controller.py
+++ b/app/Controllers/User/certifications_controller.py
@@ -3,11 +3,11 @@ from typing import List, Optional
 from uuid import UUID
 
 from sqlmodel import Session
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.certifications_service import CertificationService
 from Entities.UserDTOs.certification_entity import CreateCertification, UpdateCertification, ReadCertification
 from db import get_session
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/certifications", tags=["Certifications"])
 

--- a/app/Controllers/User/dijkstra_certificate_controller.py
+++ b/app/Controllers/User/dijkstra_certificate_controller.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.dijkstra_certificate_service import CertificateGeneratorService
 
 # Initialize logging
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/certificate", tags=["Certificate"])
 

--- a/app/Controllers/User/document_controller.py
+++ b/app/Controllers/User/document_controller.py
@@ -4,11 +4,11 @@ from typing import List
 from sqlmodel import Session
 
 from Entities.UserDTOs.document_entity import CreateDocument, UpdateDocument, ReadDocument
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.document_service import DocumentService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/document", tags=["Documents"])
 

--- a/app/Controllers/User/education_controller.py
+++ b/app/Controllers/User/education_controller.py
@@ -5,10 +5,10 @@ from sqlmodel import Session
 
 from Entities.UserDTOs.education_entity import CreateEducation, UpdateEducation, ReadEducation
 from Services.User.education_service import EducationService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/education", tags=["Education"])
 

--- a/app/Controllers/User/leetcode_controller.py
+++ b/app/Controllers/User/leetcode_controller.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlmodel import Session
 
 from db import get_session
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.leetcode_service import LeetCodeService
 from Entities.leetcode_entity import (
     ReadLeetcode,
@@ -14,7 +14,7 @@ from Entities.leetcode_entity import (
     ReadLeetcodeTag,
 )
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/leetcode", tags=["Leetcode"])
 

--- a/app/Controllers/User/links_controller.py
+++ b/app/Controllers/User/links_controller.py
@@ -3,12 +3,12 @@ from fastapi import APIRouter, Depends, Query
 from uuid import UUID
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Entities.UserDTOs.links_entity import CreateLinks, ReadLinks, UpdateLinks
 from Services.User.links_service import LinksService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/links", tags=["Links"])
 

--- a/app/Controllers/User/location_controller.py
+++ b/app/Controllers/User/location_controller.py
@@ -5,10 +5,10 @@ from sqlmodel import Session
 
 from Entities.UserDTOs.location_entity import CreateLocation, UpdateLocation, ReadLocation
 from Services.User.location_service import LocationService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/location", tags=["Locations"])
 

--- a/app/Controllers/User/profile_controller.py
+++ b/app/Controllers/User/profile_controller.py
@@ -6,11 +6,11 @@ from sqlmodel import Session
 from Entities.UserDTOs.profile_entity import CreateProfile, UpdateProfile, ReadProfile
 from Entities.UserDTOs.extended_entities import ReadProfileFull, ReadProfileWithUser
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.profile_service import ProfileService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/profile", tags=["Profiles"])
 

--- a/app/Controllers/User/projects_controller.py
+++ b/app/Controllers/User/projects_controller.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Entities.UserDTOs.projects_entity import (
     CreateProject,
     DeleteResponse,
@@ -13,7 +13,7 @@ from Entities.UserDTOs.projects_entity import (
 from Services.User.projects_service import ProjectsService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/projects", tags=["Projects"])
 

--- a/app/Controllers/User/publication_controller.py
+++ b/app/Controllers/User/publication_controller.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends
 from uuid import UUID
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Entities.UserDTOs.publication_entity import (
     CreatePublication,
     ReadPublication,
@@ -13,7 +13,7 @@ from Entities.UserDTOs.publication_entity import (
 from Services.User.publication_service import PublicationService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/publications", tags=["Publications"])
 

--- a/app/Controllers/User/statistics_controller.py
+++ b/app/Controllers/User/statistics_controller.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.github_service import GitHubService
 from Services.User.leetcode_service import LeetCodeService
 
 # Initialize logging
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/statistics", tags=["Statistics"])
 

--- a/app/Controllers/User/test_scores_controller.py
+++ b/app/Controllers/User/test_scores_controller.py
@@ -3,11 +3,11 @@ from typing import List, Optional
 from uuid import UUID
 
 from sqlmodel import Session
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Services.User.test_scores_service import TestScoresService
 from Entities.UserDTOs.test_scores_entity import CreateTestScore, UpdateTestScore, ReadTestScore
 from db import get_session
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/test-scores", tags=["Test Scores"])
 

--- a/app/Controllers/User/user_controller.py
+++ b/app/Controllers/User/user_controller.py
@@ -7,10 +7,10 @@ from sqlmodel import Session
 
 from Entities.UserDTOs.user_entity import CreateUser, ReadUserAuthDetails, UpdateUser, ReadUser, OnboardUser, OnboardCheckResponse, ReadUserCardDetails, ReadUserPersonalDetails, UpdateUserPersonalDetails
 from Services.User.user_service import UserService
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/u", tags=["Users"])
 

--- a/app/Controllers/User/volunteering_controller.py
+++ b/app/Controllers/User/volunteering_controller.py
@@ -3,12 +3,12 @@ from fastapi import APIRouter, Depends, Query
 from uuid import UUID
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Entities.UserDTOs.volunteering_entity import CreateVolunteering, ReadVolunteering, ReadVolunteeringWithRelations, UpdateVolunteering
 from Services.User.volunteering_service import VolunteeringService
 from db import get_session
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/volunteering", tags=["Volunteering"])
 

--- a/app/Controllers/User/workexperience_controller.py
+++ b/app/Controllers/User/workexperience_controller.py
@@ -3,13 +3,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from uuid import UUID
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Entities.UserDTOs.workexperience_entity import CreateWorkExperience, ReadWorkExperience, ReadWorkExperienceWithRelations, UpdateWorkExperience
 from Services.User.workexperience_service import WorkExperienceService
 from db import get_session
 from Schema.SQL.Enums.enums import EmploymentType, WorkLocationType, Domain
 
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1/wp", tags=["Work Experiences"])
 

--- a/app/Controllers/main_controller.py
+++ b/app/Controllers/main_controller.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 
 # Initialize logging
-logger = setup_logging()
+logger = get_logger()
 
 router = APIRouter(prefix="/Dijkstra/v1", tags=["Main Controller"])
 

--- a/app/Services/User/certifications_service.py
+++ b/app/Services/User/certifications_service.py
@@ -1,4 +1,4 @@
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from uuid import UUID
 from typing import List, Optional
 from sqlmodel import Session
@@ -8,7 +8,7 @@ from Utils.Exceptions.user_exceptions import CertificationNotFound
 from Entities.UserDTOs.certification_entity import CreateCertification, UpdateCertification
 
 
-logger = setup_logging()
+logger = get_logger()
 
 class CertificationService:
        

--- a/app/Services/User/dijkstra_certificate_service.py
+++ b/app/Services/User/dijkstra_certificate_service.py
@@ -1,6 +1,6 @@
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 
-logger = setup_logging()
+logger = get_logger()
 
 class CertificateGeneratorService:
     @staticmethod

--- a/app/Services/User/document_service.py
+++ b/app/Services/User/document_service.py
@@ -1,4 +1,4 @@
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from uuid import UUID
 from typing import Optional
 from sqlmodel import Session
@@ -10,7 +10,7 @@ from Entities.UserDTOs.document_entity import CreateDocument, UpdateDocument
 from Utils.Exceptions.user_exceptions import DocumentNotFound, ProfileNotFound, UserNotFound
 
 
-logger = setup_logging()
+logger = get_logger()
 
 
 class DocumentService:

--- a/app/Services/User/github_service.py
+++ b/app/Services/User/github_service.py
@@ -3,9 +3,9 @@ from typing import Dict
 import os
 from typing import Dict, Any
 from dotenv import load_dotenv
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 
-logger = setup_logging()
+logger = get_logger()
 load_dotenv()
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 

--- a/app/Services/User/leetcode_service.py
+++ b/app/Services/User/leetcode_service.py
@@ -3,7 +3,7 @@ from uuid import UUID
 import requests
 from sqlmodel import Session
 
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Config.constants import LEETCODE_API
 from Config.queries import lc_query
 from Schema.SQL.Models.models import Leetcode, LeetcodeBadges, LeetcodeTags
@@ -27,7 +27,7 @@ from Utils.Exceptions.user_exceptions import (
     LeetcodeTagNotFound,
 )
 
-logger = setup_logging()
+logger = get_logger()
 
 
 class LeetCodeService:

--- a/app/Services/User/test_scores_service.py
+++ b/app/Services/User/test_scores_service.py
@@ -1,4 +1,4 @@
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from uuid import UUID
 from typing import List, Optional
 from sqlmodel import Session
@@ -7,7 +7,7 @@ from Schema.SQL.Models.models import TestScores
 from Utils.Exceptions.user_exceptions import TestScoreNotFound
 from Entities.UserDTOs.test_scores_entity import CreateTestScore, UpdateTestScore
 
-logger = setup_logging()
+logger = get_logger()
 
 class TestScoresService:
        

--- a/app/Services/User/user_service.py
+++ b/app/Services/User/user_service.py
@@ -12,10 +12,10 @@ from Schema.SQL.Models.models import User, Profile, Links, Location
 from Utils.Exceptions.user_exceptions import GitHubUsernameAlreadyExists, GitHubUsernameNotFound, ProfileNotFound, UserNotFound
 from Entities.UserDTOs.location_entity import UpdateLocation, CreateLocation
 from Utils.Helpers.gitripper_client import GitRipperClient, GitRipperClientError
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 import os
 
-logger = setup_logging()
+logger = get_logger()
 class UserService:
     def __init__(self, session: Session):
         self.repo = UserRepository(session)

--- a/app/Settings/logging_config.py
+++ b/app/Settings/logging_config.py
@@ -5,11 +5,14 @@ from dotenv import load_dotenv
 import re
 import os
 
-def setup_logging():
+def get_logger():
     load_dotenv()
     level = os.getenv("LOGGING_LEVEL")
 
     logger = logging.getLogger()
+    if logger.handlers:
+        return logger  # prevent duplicate handlers
+    
     logger.setLevel(logging.DEBUG)
 
     # File handler
@@ -28,7 +31,7 @@ def setup_logging():
     else:
         console_handler.setLevel(logging.INFO)
         file_handler.setLevel(logging.INFO)
-        
+    
     # Formatter
     formatter = logging.Formatter('%(levelname)s - %(asctime)s - | %(filename)s | - %(message)s')
     file_handler.setFormatter(formatter)
@@ -37,5 +40,4 @@ def setup_logging():
     # Add handlers to the logger
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
-
     return logger

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from Settings.logging_config import setup_logging
+from Settings.logging_config import get_logger
 from Controllers import main_controller
 from Controllers.Opportunities import job_controller
 from Controllers.User import (
@@ -42,7 +42,7 @@ app.add_middleware(
 )
 
 # Initialize logging
-logger = setup_logging()
+logger = get_logger()
 
 @app.on_event("startup")
 def on_startup():


### PR DESCRIPTION
Every time we invoke setup_logging, it registers a new logging handler. This results in duplicate logs.
We need to register handlers only if they are not already present.